### PR TITLE
Fix refresh bug with sessionStorage & prevent duplicate client entries

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,18 +7,46 @@ import { VideoContextProvider } from './contexts/videoContext';
 import { ClientContextProvider } from './contexts/clientContext';
 
 interface SocketContextProps {
-  hostSocket: any;
-  updateHostSocketBuffer: any;
+  clientId: string;
+  setClientId: (clientId: string) => void;
+  clientDisplayName: string;
+  setClientDisplayName: (displayName: string) => void;
+  roomYoutubeId: string; // used by hosts only
+  setRoomYoutubeId: (youtubeId: string) => void; // used by hosts only
 }
 
 export const SocketContext = createContext({} as SocketContextProps);
 
 const App = () => {
-  const [socket, setSocket] = useState({});
+  const [clientId, setClientId] = useState(
+    sessionStorage.clientId ? sessionStorage.clientId : ''
+  );
+  const setClientIdWrapper = (id: string) => {
+    setClientId(id);
+    sessionStorage.setItem('clientId', id);
+  };
+  const [clientDisplayName, setClientDisplayName] = useState(
+    sessionStorage.clientDisplayName ? sessionStorage.clientDisplayName : ''
+  );
+  const setClientDisplayNameWrapper = (displayName: string) => {
+    setClientDisplayName(displayName);
+    sessionStorage.setItem('clientDisplayName', displayName);
+  };
+  const [roomYoutubeId, setRoomYoutubeId] = useState(
+    sessionStorage.roomYoutubeId ? sessionStorage.roomYoutubeId : ''
+  );
+  const setRoomYoutubIdWrapper = (youtubeId: string) => {
+    setRoomYoutubeId(youtubeId);
+    sessionStorage.setItem('roomYoutubeId', youtubeId);
+  };
 
   const socketContext = {
-    hostSocket: socket,
-    updateHostSocketBuffer: setSocket,
+    clientId,
+    setClientId: setClientIdWrapper,
+    clientDisplayName,
+    setClientDisplayName: setClientDisplayNameWrapper,
+    roomYoutubeId,
+    setRoomYoutubeId: setRoomYoutubIdWrapper,
   };
 
   return (
@@ -26,7 +54,7 @@ const App = () => {
       <ClientContextProvider>
         <VideoContextProvider>
           <SocketContext.Provider value={socketContext}>
-            <Route exact path="/room/:id" component={Room} />
+            <Route exact path="/room/:roomId" component={Room} />
             <Route exact path="/" component={Landing} />
           </SocketContext.Provider>
         </VideoContextProvider>

--- a/client/src/components/Landing.tsx
+++ b/client/src/components/Landing.tsx
@@ -25,6 +25,7 @@ const Landing = (props: RouteComponentProps & any) => {
       displayName,
       undefined,
       undefined,
+      undefined,
       youtubeId
     );
 

--- a/client/src/components/Landing.tsx
+++ b/client/src/components/Landing.tsx
@@ -2,37 +2,47 @@ import React, { useState, useContext, ChangeEvent, FormEvent } from 'react';
 import { createConnection } from '../utils/socket-client';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { SocketContext } from '../App';
-import { extractVideoID } from '../utils/helpers';
+import { extractVideoId } from '../utils/helpers';
 
 const Landing = (props: RouteComponentProps & any) => {
   const [createDisplayName, setCreateDisplayName] = useState('');
+  const [youtubeLink, setYoutubeLink] = useState('');
   const [joinRoomId, setJoinRoomId] = useState('');
   const [joinDisplayName, setJoinDisplayName] = useState('');
-  const [youtubeLink, setYoutubeLink] = useState('');
-  const { updateHostSocketBuffer } = useContext(SocketContext);
+
+  const { setClientId, setClientDisplayName, setRoomYoutubeId } = useContext(
+    SocketContext
+  );
 
   const startSession = async (
     event: FormEvent,
     displayName: string,
-    youtubeURL: string
+    youtubeUrl: string
   ) => {
     event.preventDefault();
-    const youtubeID = extractVideoID(youtubeURL);
-    const newSocket = await createConnection(displayName, undefined, youtubeID);
+    const youtubeId = extractVideoId(youtubeUrl);
+    const newSocket = await createConnection(
+      displayName,
+      undefined,
+      undefined,
+      youtubeId
+    );
 
-    updateHostSocketBuffer(newSocket);
+    setClientId(newSocket.id);
+    setClientDisplayName(displayName);
+    setRoomYoutubeId(youtubeId);
 
     props.history.push({
       pathname: `/room/${newSocket.id}`,
-      state: { hostId: newSocket.id, displayName, youtubeID },
-      socket: newSocket,
+      socket: newSocket, // Send socket object as a prop to prevent redundant connection creation
     });
   };
 
   const joinSession = (roomId: string, displayName: string) => {
+    setClientDisplayName(displayName);
+
     props.history.push({
       pathname: `/room/${roomId}`,
-      state: { displayName },
     });
   };
 

--- a/client/src/components/Room.tsx
+++ b/client/src/components/Room.tsx
@@ -32,16 +32,27 @@ interface Client {
 }
 
 const Room = ({ location, match }: RoomProps & any) => {
+  // Global client state/mutators persisted with sessionStorage
+  const {
+    clientId,
+    setClientId,
+    clientDisplayName,
+    setClientDisplayName,
+    roomYoutubeId,
+  } = useContext(SocketContext);
+
   const [clients, setClients] = useState(
-    location.state ? [location.state.displayName] : []
+    clientId && clientDisplayName
+      ? [{ id: clientId, name: clientDisplayName }]
+      : []
   );
+  const [displayName, setDisplayName] = useState(clientDisplayName);
+
   const [enterDisplayName, setEnterDisplayName] = useState(false);
   const [displayNameInput, setDisplayNameInput] = useState('');
-  const [displayName, setDisplayName] = useState(
-    location.state ? location.state.displayName : ''
-  );
-  const { hostSocket } = useContext(SocketContext);
-  const [socket, setSocket] = useState(hostSocket);
+
+  const [socket, setSocket] = useState(location.socket ? location.socket : {});
+
   const { clientDispatch, clientData } = useContext(ClientContext);
   const { videoDispatch } = useContext(VideoContext);
   const dispatches = {
@@ -51,32 +62,49 @@ const Room = ({ location, match }: RoomProps & any) => {
 
   useEffect(() => {
     connectClient();
-    // eslint-disable-next-line
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientId, clientDisplayName, roomYoutubeId]);
 
-  // Creates a socket connection to server if client is not room host
   const connectClient = async () => {
-    if (location.state) {
-      const { hostId, youtubeID } = location.state;
-
-      // No hostId was sent as prop, therefore new client. Create connection
-      if (!hostId) {
-        const { id } = match.params;
-        const newSocket = await createConnection(displayName, id);
-        updateClientList(newSocket);
-        setSocket(newSocket);
-        roomSocketEvents(newSocket, dispatches);
-      }
-      // hostId was sent as prop, just subscibe to updateClientList broadcasts
-      else {
-        clientDispatch({ type: ClientStates.UPDATE_YOUTUBE_ID, youtubeID });
-        updateClientList(hostSocket);
-        setSocket(location.socket);
-        roomSocketEvents(socket, dispatches);
-      }
+    // Room host with socket from Landing page
+    if (location.socket) {
+      clientDispatch({
+        type: ClientStates.UPDATE_YOUTUBE_ID,
+        youtubeID: roomYoutubeId,
+      });
+      updateClientList(location.socket);
+      setSocket(location.socket);
+      roomSocketEvents(location.socket, dispatches);
     }
-    // Entered room from direct link rather than redirect from landing page. Prompt for displayName
-    else {
+    // Joining client or Room host that already made connection and refreshed
+    else if (clientId && clientDisplayName) {
+      const { roomId } = match.params;
+      const socketConnection = await createConnection(
+        clientDisplayName,
+        roomId,
+        clientId,
+        undefined
+      );
+      updateClientList(socketConnection);
+      setSocket(socketConnection);
+      roomSocketEvents(socketConnection, dispatches);
+    }
+    // Joining clients: inputted displayName
+    else if (!clientId && clientDisplayName) {
+      const { roomId } = match.params;
+      const socketConnection = await createConnection(
+        clientDisplayName,
+        roomId,
+        undefined,
+        undefined
+      );
+      setClientId(socketConnection.id);
+      updateClientList(socketConnection);
+      setSocket(socketConnection);
+      roomSocketEvents(socketConnection, dispatches);
+    }
+    // Joining client from direct URL, prompt for displayName
+    else if (!clientId && !clientDisplayName) {
       setEnterDisplayName(true);
     }
   };
@@ -96,12 +124,8 @@ const Room = ({ location, match }: RoomProps & any) => {
   const handleFormSubmit = async (event: FormEvent) => {
     event.preventDefault();
 
-    const { id } = match.params;
-    const newSocket = await createConnection(displayNameInput, id);
     setDisplayName(displayNameInput);
-    updateClientList(newSocket);
-    setSocket(newSocket);
-    roomSocketEvents(newSocket, dispatches);
+    setClientDisplayName(displayNameInput);
     setEnterDisplayName(false);
   };
 

--- a/client/src/components/Room.tsx
+++ b/client/src/components/Room.tsx
@@ -63,7 +63,7 @@ const Room = ({ location, match }: RoomProps & any) => {
   useEffect(() => {
     connectClient();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clientId, clientDisplayName, roomYoutubeId]);
+  }, [clientDisplayName, roomYoutubeId]);
 
   const connectClient = async () => {
     // Room host with socket from Landing page
@@ -83,8 +83,10 @@ const Room = ({ location, match }: RoomProps & any) => {
         clientDisplayName,
         roomId,
         clientId,
+        undefined,
         undefined
       );
+      setClientId(socketConnection.id);
       updateClientList(socketConnection);
       setSocket(socketConnection);
       roomSocketEvents(socketConnection, dispatches);
@@ -95,6 +97,7 @@ const Room = ({ location, match }: RoomProps & any) => {
       const socketConnection = await createConnection(
         clientDisplayName,
         roomId,
+        undefined,
         undefined,
         undefined
       );

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,5 +1,5 @@
-export const extractVideoID = (youtubeLink: string) => {
+export const extractVideoId = (youtubeLink: string): string => {
   const expression = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
   const linkMatches = youtubeLink.match(expression);
-  return linkMatches && linkMatches[7].length === 11 ? linkMatches[7] : false;
+  return linkMatches && linkMatches[7].length === 11 ? linkMatches[7] : '';
 };

--- a/client/src/utils/socket-client.ts
+++ b/client/src/utils/socket-client.ts
@@ -7,7 +7,8 @@ const socketServerDomain = 'http://localhost:5000';
 export const createConnection = (
   displayName: string,
   roomId?: string,
-  youtubeID?: string | false
+  clientId?: string,
+  youtubeID?: string
 ): Promise<SocketIOClient.Socket> => {
   return new Promise((resolve) => {
     const socket = io(socketServerDomain);
@@ -15,7 +16,8 @@ export const createConnection = (
     socket.on('connect', () => {
       const clientData = {
         roomId: roomId ? roomId : socket.id,
-        clientId: socket.id,
+        // if a clientID is present in sessionStorage, use it again
+        clientId: clientId ? clientId : socket.id,
         clientName: displayName,
         youtubeID,
       };

--- a/client/src/utils/socket-client.ts
+++ b/client/src/utils/socket-client.ts
@@ -7,7 +7,8 @@ const socketServerDomain = 'http://localhost:5000';
 export const createConnection = (
   displayName: string,
   roomId?: string,
-  clientId?: string,
+  oldClientId?: string,
+  newClientId?: string,
   youtubeID?: string
 ): Promise<SocketIOClient.Socket> => {
   return new Promise((resolve) => {
@@ -16,8 +17,9 @@ export const createConnection = (
     socket.on('connect', () => {
       const clientData = {
         roomId: roomId ? roomId : socket.id,
+        oldClientId,
         // if a clientID is present in sessionStorage, use it again
-        clientId: clientId ? clientId : socket.id,
+        newClientId: newClientId ? newClientId : socket.id,
         clientName: displayName,
         youtubeID,
       };

--- a/server/utils/Rooms.ts
+++ b/server/utils/Rooms.ts
@@ -8,7 +8,7 @@ export interface ClientMap {
 }
 
 export interface RoomMap {
-  [roomId: string]: { clients: Client[], youtubeID: string };
+  [roomId: string]: { clients: Client[]; youtubeID: string };
 }
 
 /**
@@ -27,7 +27,7 @@ class Rooms {
     if (!this.roomMap[roomId]) {
       const roomDetails = {
         clients: [],
-        youtubeID
+        youtubeID,
       };
       this.roomMap[roomId] = roomDetails;
     }
@@ -41,16 +41,13 @@ class Rooms {
   }
 
   addClient(roomId: string, clientId: string, clientName: string): void {
+    if (this.clientMap[clientId]) {
+      return;
+    }
     if (this.roomMap[roomId]) {
-      let createClient:boolean = true;
-      this.roomMap[roomId].clients.forEach((client) => {
-        client.name === clientName ? createClient = false : createClient = true;
-      });
-      if (createClient) {
-        const newClient: Client = { id: clientId, name: clientName };
-        this.roomMap[roomId].clients.push(newClient);
-        this.clientMap[clientId] = roomId;
-      }
+      const newClient: Client = { id: clientId, name: clientName };
+      this.roomMap[roomId].clients.push(newClient);
+      this.clientMap[clientId] = roomId;
     } else {
       throw new Error('Room with this ID does not exist');
     }

--- a/server/utils/Rooms.ts
+++ b/server/utils/Rooms.ts
@@ -53,6 +53,20 @@ class Rooms {
     }
   }
 
+  updateClientId(roomId: string, oldClientId: string, newClientId: string) {
+    if (this.roomMap[roomId]) {
+      const oldClient = this.roomMap[roomId].clients.find(
+        (client: Client) => client.id === oldClientId);
+      if (oldClient) oldClient.id = newClientId;
+      else throw new Error('Old client can\'t be found');
+
+      delete this.clientMap[oldClientId];
+      this.clientMap[newClientId] = roomId;
+    } else {
+      throw new Error('Room with this ID does not exist');
+    }
+  }
+
   getClientRoomId(clientId: string): string {
     if (this.clientMap[clientId]) {
       return this.clientMap[clientId];

--- a/server/utils/socket-handler.ts
+++ b/server/utils/socket-handler.ts
@@ -17,12 +17,17 @@ const socketHandler = (io: WebSocketServer) => {
 
       Rooms.addRoom(roomId, youtubeID);
       Rooms.addClient(roomId, clientId, clientName);
-      // tslint:disable-next-line: no-console
-      Rooms.getRoomClients(roomId).forEach((client) => { console.log(client); });
+      Rooms.getRoomClients(roomId).forEach((client) => {
+        // tslint:disable-next-line: no-console
+        console.log(client);
+      });
 
       socket.broadcast
         .to(roomId)
-        .emit('notifyClient', createClientNotifier('clientJoin', { roomId, clientId, clientName }));
+        .emit(
+          'notifyClient',
+          createClientNotifier('clientJoin', { roomId, clientId, clientName })
+        );
 
       io.to(roomId).emit('updateClientList', Rooms.getRoomClients(roomId));
 
@@ -31,7 +36,7 @@ const socketHandler = (io: WebSocketServer) => {
         socket.emit(
           'notifyClient',
           createClientNotifier('CHANGE_VIDEO', {
-            youtubeID: room.youtubeID
+            youtubeID: room.youtubeID,
           })
         );
       }
@@ -39,31 +44,28 @@ const socketHandler = (io: WebSocketServer) => {
 
     socket.on('videoStateChange', (data) => {
       const client = Rooms.getClient(socket.id);
-      socket.broadcast.to(
-        Rooms.getClientRoomId(client.id)).emit(
-          'notifyClient',
-          createClientNotifier('updateVideoState', {
-            type: data.type,
-            ...data.payload,
-            client: {
-              name: client.name,
-              socketId: socket.id
-            }
-          })
-        );
+      socket.broadcast.to(Rooms.getClientRoomId(client.id)).emit(
+        'notifyClient',
+        createClientNotifier('updateVideoState', {
+          type: data.type,
+          ...data.payload,
+          client: {
+            name: client.name,
+            socketId: socket.id,
+          },
+        })
+      );
     });
 
     socket.on('newMessage', (message) => {
       const client = Rooms.getClient(socket.id);
       if (client) {
-        io.to(
-          Rooms.getClientRoomId(client.id)).emit(
-            'notifyClient',
-            createUserMessage(client.name, client.id, message)
-          );
+        io.to(Rooms.getClientRoomId(client.id)).emit(
+          'notifyClient',
+          createUserMessage(client.name, client.id, message)
+        );
       }
     });
-
   });
 };
 

--- a/server/utils/socket-handler.ts
+++ b/server/utils/socket-handler.ts
@@ -6,17 +6,18 @@ const socketHandler = (io: WebSocketServer) => {
   // Client connection event
   io.on('connection', (socket: Socket) => {
     // tslint:disable-next-line: no-console
-    console.log(`New socket established: ${socket.id}`);
+    console.log(`\nNew socket established: ${socket.id}`);
 
     // Subscribes client to roomId event emitter & broadcasts this info to other clients in room
     socket.on('join', (clientData) => {
       // tslint:disable-next-line: no-console
       console.log('join broadcast triggered');
-      const { roomId, clientId, clientName, youtubeID } = clientData;
+      const { roomId, oldClientId, newClientId, clientName, youtubeID } = clientData;
       socket.join(roomId);
 
       Rooms.addRoom(roomId, youtubeID);
-      Rooms.addClient(roomId, clientId, clientName);
+      if (oldClientId) Rooms.updateClientId(roomId, oldClientId, newClientId);
+      Rooms.addClient(roomId, newClientId, clientName);
       Rooms.getRoomClients(roomId).forEach((client) => {
         // tslint:disable-next-line: no-console
         console.log(client);
@@ -26,7 +27,7 @@ const socketHandler = (io: WebSocketServer) => {
         .to(roomId)
         .emit(
           'notifyClient',
-          createClientNotifier('clientJoin', { roomId, clientId, clientName })
+          createClientNotifier('clientJoin', { roomId, newClientId, clientName })
         );
 
       io.to(roomId).emit('updateClientList', Rooms.getRoomClients(roomId));


### PR DESCRIPTION
Before, on page refreshes for room host, the app would crash. Now, when a refresh is made, the frontend will make a new socket connection with the server, but the ID from the first original connection will be used to identify the client so that duplicate client entries aren't added to the room.

Also, instead of checking for names existing in the room to prevent adding duplicates, now it just checks if the clientId exists already in general.