### PR TITLE
Remove redundant O(n) spread syntax for 'addToPlaylist' event on frontend

### DIFF
--- a/client/src/reducers/clientReducer.tsx
+++ b/client/src/reducers/clientReducer.tsx
@@ -8,13 +8,9 @@ export const clientReducer = (state: any, action: any) => {
         youtubeID: action.youtubeID,
       };
     case ClientStates.UPDATE_PLAYLIST:
-      const { youtubeID } = action.data;
       return {
         ...state,
-        playlist: [
-          ...state.playlist,
-          youtubeID,
-        ],
+        playlist: action.playlist,
       };
 
     case ClientStates.CHANGE_VIDEO:
@@ -26,7 +22,7 @@ export const clientReducer = (state: any, action: any) => {
     case ClientStates.DELETE_VIDEO:
       return {
         ...state,
-        playlist: action.playlist
+        playlist: action.playlist,
       };
 
     case ClientStates.UPDATE_CHAT_MESSAGES:

--- a/client/src/utils/socket-client.ts
+++ b/client/src/utils/socket-client.ts
@@ -87,7 +87,7 @@ export const roomSocketEvents = (
       case 'addToPlaylist':
         clientDispatch({
           type: ClientStates.UPDATE_PLAYLIST,
-          data,
+          playlist: data.playlist,
         });
         break;
 

--- a/server/utils/Playlist.ts
+++ b/server/utils/Playlist.ts
@@ -1,12 +1,12 @@
 const LinkedList = require('linked-list');
 
-export interface PlaylistMap{
-  [youtubeID: string] : typeof LinkedList.Item;
+export interface PlaylistMap {
+  [youtubeID: string]: typeof LinkedList.Item;
 }
 
-export class Playlist{
+export class Playlist {
   private list: typeof LinkedList;
-  private map: Map<string, typeof LinkedList.Item>;
+  private map: PlaylistMap;
 
   constructor() {
     this.list = new LinkedList();
@@ -31,12 +31,12 @@ export class Playlist{
 
   getNextVideo(): typeof LinkedList.Item {
     // to be used for autoplay
-    const value: typeof LinkedList.Item =  this.list.head;
+    const value: typeof LinkedList.Item = this.list.head;
     const node: typeof LinkedList.Item = this.map.get(value);
     console.log('value', value); // tslint:disable-line
   }
 
-  getPlayListIds(): string[] {
+  getPlaylistIds(): string[] {
     return [...this.map.keys()];
   }
 }

--- a/server/utils/Rooms.ts
+++ b/server/utils/Rooms.ts
@@ -10,7 +10,11 @@ export interface ClientMap {
 }
 
 export interface RoomMap {
-  [roomId: string]: { clients: Client[], youtubeID: string, playlist: Playlist };
+  [roomId: string]: {
+    clients: Client[];
+    youtubeID: string;
+    playlist: Playlist;
+  };
 }
 
 /**
@@ -19,12 +23,10 @@ export interface RoomMap {
 class Rooms {
   private roomMap: RoomMap;
   private clientMap: ClientMap; // maps any socket.id to its respective roomId
-  // private playlist: Playlist;
 
   constructor() {
     this.roomMap = {};
     this.clientMap = {};
-    // this.playlist = new Playlist();
   }
 
   addRoom(roomId: string, youtubeID: string): void {
@@ -32,7 +34,7 @@ class Rooms {
       const roomDetails = {
         clients: [],
         youtubeID,
-        playlist: new Playlist()
+        playlist: new Playlist(),
       };
       this.roomMap[roomId] = roomDetails;
     }
@@ -61,7 +63,8 @@ class Rooms {
   updateClientId(roomId: string, oldClientId: string, newClientId: string) {
     if (this.roomMap[roomId]) {
       const oldClient = this.roomMap[roomId].clients.find(
-        (client: Client) => client.id === oldClientId);
+        (client: Client) => client.id === oldClientId
+      );
       if (oldClient) oldClient.id = newClientId;
       else throw new Error('Old client can\'t be found');
 
@@ -103,13 +106,13 @@ class Rooms {
     }
   }
 
-  updatePlaylist(roomID: string, youtubeID:string): void {
+  addVideo(roomID: string, youtubeID: string): void {
     if (this.roomMap[roomID]) {
       this.roomMap[roomID].playlist.addVideo(youtubeID);
     }
   }
 
-  deleteVideo(roomID: string, youtubeID:string): void {
+  deleteVideo(roomID: string, youtubeID: string): void {
     if (this.roomMap[roomID]) {
       this.roomMap[roomID].playlist.deleteVideo(youtubeID);
     }
@@ -122,6 +125,9 @@ class Rooms {
     }
   }
 
+  getPlaylistVideoIds(roomId: string): string[] {
+    return this.roomMap[roomId].playlist.getPlaylistIds();
+  }
 }
 
 export default new Rooms();

--- a/server/utils/socket-notifier.ts
+++ b/server/utils/socket-notifier.ts
@@ -4,7 +4,7 @@ export const createClientNotifier = (
 ): object => {
   return {
     notification,
-    details
+    details,
   };
 };
 
@@ -21,18 +21,14 @@ export const createUserMessage = (
   };
 };
 
-export const createPlaylistItem = (
-  youtubeID: string,
-): object => {
+export const createPlaylistItem = (playlist: string[]): object => {
   return {
     notification: 'addToPlaylist',
-    youtubeID,
+    playlist,
   };
 };
 
-export const deletePlaylistItem = (
-  playlist: string[],
-): object => {
+export const deletePlaylistItem = (playlist: string[]): object => {
   return {
     notification: 'deletePlaylistItem',
     playlist,


### PR DESCRIPTION
Before this change, when videos were added to the queue, the backend performs it efficiently in O(1) time, but the frontend does an unnecessary 
```
playlist: [ ...state.playlist, newVideoYoutubeID ]
```
This would be a O(n) time operation on the frontend which isn't necessary. Now, the backend performs the modification in O(1) time, and then sends the updated queue state. The frontend simply just consumes the updated state