### PR TITLE
Remove disconnected clients

### DIFF
--- a/client/src/reducers/clientReducer.tsx
+++ b/client/src/reducers/clientReducer.tsx
@@ -7,6 +7,7 @@ export const clientReducer = (state: any, action: any) => {
         ...state,
         youtubeID: action.youtubeID,
       };
+
     case ClientStates.UPDATE_PLAYLIST:
       return {
         ...state,

--- a/client/src/utils/enums.ts
+++ b/client/src/utils/enums.ts
@@ -9,7 +9,6 @@ export enum VideoStates {
 export enum ClientStates {
   UPDATE_CLIENT_NAME,
   UPDATE_YOUTUBE_ID,
-  UPDATE_CLIENT_LIST,
   UPDATE_CHAT_MESSAGES,
   UPDATE_PLAYLIST,
   DELETE_VIDEO,

--- a/client/src/utils/socket-client.ts
+++ b/client/src/utils/socket-client.ts
@@ -16,9 +16,8 @@ export const createConnection = (
     socket.on('connect', () => {
       const clientData = {
         roomId: roomId ? roomId : socket.id,
-        oldClientId,
         // if a clientID is present in sessionStorage, use it again
-        newClientId: socket.id,
+        clientId: socket.id,
         clientName: displayName,
         youtubeID,
       };

--- a/server/utils/Rooms.ts
+++ b/server/utils/Rooms.ts
@@ -60,16 +60,19 @@ class Rooms {
     }
   }
 
-  updateClientId(roomId: string, oldClientId: string, newClientId: string) {
+  removeClient(roomId: string, clientId: string) {
+    if (!this.clientMap[clientId]) {
+      return;
+    }
     if (this.roomMap[roomId]) {
-      const oldClient = this.roomMap[roomId].clients.find(
-        (client: Client) => client.id === oldClientId
-      );
-      if (oldClient) oldClient.id = newClientId;
-      else throw new Error('Old client can\'t be found');
-
-      delete this.clientMap[oldClientId];
-      this.clientMap[newClientId] = roomId;
+      const clientList: Client[] = this.getRoomClients(roomId);
+      for (let i = 0; i < clientList.length; i += 1) {
+        const client = clientList[i];
+        if (client.id === clientId) {
+          clientList.splice(i, 1);
+          return clientList;
+        }
+      }
     } else {
       throw new Error('Room with this ID does not exist');
     }


### PR DESCRIPTION
Clients who leave the room are removed from the client list. The _updateClientId_ function in the backend is not needed anymore because when refreshing the page, the client will be disconnected and removed from the client list in the frontend and backend. The _updateClientId_ function would cause the server to break since it wouldn't be able to find the client anymore. Now, any client that refreshes will just be moved to the end of the client list.

The issue of duplicating a tab, refreshing the first tab, and then causing the app to crash is now resolved.